### PR TITLE
Bettert hreading validation while getting new OCID API key

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.fitchfamily.android.gsmlocation"
-    android:versionCode="23"
-    android:versionName="0.9.0">
+    android:versionCode="24"
+    android:versionName="0.9.1">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/prefsFragment.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/prefsFragment.java
@@ -202,7 +202,6 @@ public class prefsFragment extends PreferenceFragment {
 
                 if (result.getStatusCode() == 200) {
                     String responseFromServer = result.getResponseFromServer();
-                    Log.d(TAG, responseFromServer);
                     return responseFromServer;
                 } else if (result.getStatusCode() == 503) {
                     // Check for HTTP error code 503 which is returned when user is trying to request


### PR DESCRIPTION
Current solution doesn't wait until API key is downloaded on main thread, instead it passes validation on background thread and changes value if successful.

Next PR: 
 * add filtering MMC by country (no need to know MMC codes or looking up on wiki)