### PR TITLE
Support Marshmallow's runtime permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,11 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:parentActivityName=".SettingsActivity" />
+
+        <activity
+            android:name=".ReqLocationPermActivity"
+            android:launchMode="singleTop"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/ReqLocationPermActivity.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/ReqLocationPermActivity.java
@@ -1,0 +1,51 @@
+package org.fitchfamily.android.gsmlocation;
+
+import android.Manifest;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.NotificationManager;
+import android.content.DialogInterface;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+import static org.fitchfamily.android.gsmlocation.LogUtils.makeLogTag;
+
+@TargetApi(23)
+public class ReqLocationPermActivity extends Activity {
+    private static final String TAG = makeLogTag(ReqLocationPermActivity.class);
+    private static final boolean DEBUG = Config.DEBUG;
+
+    public static final int NOTIFICATION_ID = 1;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        if (DEBUG) Log.d(TAG, "onCreate() called");
+        super.onCreate(savedInstanceState);
+
+        requestPermissions(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION}, 0);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        if (DEBUG) Log.d(TAG, "onRequestPermissionsResult() called");
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this).setTitle(R.string.app_name)
+                .setCancelable(false).setPositiveButton(android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                finish();
+                            }
+                        });
+
+        if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            builder.setMessage(R.string.dialog_location_perm_granted).show();
+        } else {
+            builder.setMessage(R.string.dialog_location_perm_denied).show();
+        }
+
+        ((NotificationManager) getSystemService(NOTIFICATION_SERVICE)).cancel(NOTIFICATION_ID);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,5 +68,12 @@
     <string name="st_FAILED">FAILED</string>
     <string name="st_SUCCESS">SUCCESS</string>
     <string name="st_UNKNOWN">UNKNOWN</string>
+
+    <!-- Strings related to requesting/granting permissions -->
+    <string name="notification_location_permission">Tap to grant the necessary location permission.</string>
+    <string name="dialog_location_perm_granted">Now disable and re-enable GSM Location Service in the UnifiedNlp settings to make it work. Alternatively, disable and re-enable location in the quick settings menu.</string>
+    <string name="dialog_location_perm_denied">The service won\'t be able to gather information about mobile network cells and will be useless until you grant the location permission.</string>
+    <string name="dialog_write_ext_storage_perm_granted">You must grant permission to access files on the device, the database can\'t be generated without it.</string>
+
 </resources>
 


### PR DESCRIPTION
In PR #37 I've bumped the target SDK to 23, but forgot to request permissions at runtime on API 23 devices. This rendered the backend useless on Marshmallow. This commit fixes it.

We need to request two dangerous permissions: WRITE_EXTERNAL_STORAGE for on-device database generation and the crucial ACCESS_COARSE_LOCATION for GsmService's cell info listeners, etc.

WRITE_EXTERNAL_STORAGE is now requested in the SettingsFragment, after tapping "Generate Database". ACCESS_COARSE_LOCATION needed a different approach. Since you can check if a permission is granted in a Service but request it only from an Activity, I've created a separate activity with a translucent theme just for that. After UnifiedNlp connects to GsmService and it finds out the ACCESS_COARSE_LOCATION permission is not granted, it will show a notification after tapping which the new ReqLocationPermActivity will be run and request the perm or show rationale. SettingsFragment could also handle this, so a new activity wasn't exactly necessary, but I didn't want to make it any bigger since it already does a lot of things. The code is clearer this way.

