### PR TITLE
fixed downloading of small MCC

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/async/DownloadSpiceRequest.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/async/DownloadSpiceRequest.java
@@ -325,9 +325,8 @@ public class DownloadSpiceRequest extends SpiceRequest<DownloadSpiceRequest.Resu
     }
 
     private void getData(Source source, int progressStart, int progressEnd) throws Exception {
-        // no risk, because progressStart + (x * 0) == progressStart
-        if(progressStart > progressEnd) {
-            throw new IllegalArgumentException(progressStart + " > " + progressEnd);
+        if(progressStart >= progressEnd) {
+            throw new IllegalArgumentException(progressStart + " >= " + progressEnd);
         }
 
         final long progressSize = progressEnd - progressStart;

--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/async/DownloadSpiceRequest.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/async/DownloadSpiceRequest.java
@@ -325,8 +325,9 @@ public class DownloadSpiceRequest extends SpiceRequest<DownloadSpiceRequest.Resu
     }
 
     private void getData(Source source, int progressStart, int progressEnd) throws Exception {
-        if(progressStart >= progressEnd) {
-            throw new IllegalArgumentException(progressStart + " >= " + progressEnd);
+        // no risk, because progressStart + (x * 0) == progressStart
+        if(progressStart > progressEnd) {
+            throw new IllegalArgumentException(progressStart + " > " + progressEnd);
         }
 
         final long progressSize = progressEnd - progressStart;


### PR DESCRIPTION
This allows downloading MCC data if one MCC contains only some records (compared to other used sources) by allowing a Source to produce zero progress.

This should fix https://github.com/n76/Local-GSM-Backend/issues/47.