### PR TITLE
Fix gradle dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         // replace with the current version of the Android plugin


### PR DESCRIPTION
'com.android.tools.build:gradle:2.2.2' is not available in mavenCentral, but in jcenter. If you need to use a special buildscript in here, you should add jcenter to the buildscript repository list, just like in the root projects ../build.gradle.