### PR TITLE
Increase max input length of ext database path

### DIFF
--- a/app/src/main/res/xml/settings_prefs.xml
+++ b/app/src/main/res/xml/settings_prefs.xml
@@ -28,7 +28,7 @@
         <EditTextPreference
             android:dialogTitle="@string/ext_db_description"
             android:key="ext_db_preference"
-            android:maxLength="72"
+            android:maxLength="1023"
             android:title="@string/ext_db_label" />
     </PreferenceCategory>
     


### PR DESCRIPTION
Increase the maxLength for the input of the external database path to 1023. The limit if 75 would prevent some reasonable path from being configured. Fixes #117