### PR TITLE
Fix for #116: For devices >= LOLLIPOP use ACTION_OPEN_DOCUMENT_TREE i…

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/ui/MainActivity.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/ui/MainActivity.java
@@ -164,4 +164,8 @@ public class MainActivity extends AppCompatActivity implements UpdateDatabaseFra
     public enum Action {
         request_permission
     }
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+    }
 }

--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/ui/settings/AdvancedSettingsFragment.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/ui/settings/AdvancedSettingsFragment.java
@@ -1,9 +1,13 @@
 package org.fitchfamily.android.gsmlocation.ui.settings;
 
+import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.Preference;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 import com.github.machinarius.preferencefragment.PreferenceFragment;
 import com.octo.android.robospice.SpiceManager;
@@ -24,7 +28,10 @@ import java.util.Set;
 @EFragment
 @PreferenceScreen(R.xml.settings_prefs)
 public class AdvancedSettingsFragment extends PreferenceFragment implements Preference.OnPreferenceChangeListener {
+    private static final int PREF_DB_PATH_REQUEST_CODE = 42;
+    private static final String PREF_KEY_DB_PATH = "ext_db_preference";
     private SpiceManager spiceManager = new SpiceManager(SpiceService.class);
+
 
     private SharedPreferences sp;
 
@@ -46,10 +53,11 @@ public class AdvancedSettingsFragment extends PreferenceFragment implements Pref
     protected void init() {
         sp = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
+        Preference prefDbPath = findPreference(PREF_KEY_DB_PATH);
         bindPreferenceSummaryToValue(findPreference("oci_key_preference"));
         bindPreferenceSummaryToValue(findPreference("mcc_filter_preference"));
         bindPreferenceSummaryToValue(findPreference("mnc_filter_preference"));
-        bindPreferenceSummaryToValue(findPreference("ext_db_preference"));
+        bindPreferenceSummaryToValue(prefDbPath);
 
         // only enable settings when the database download is not running
         setPreferencesEnabled(false);
@@ -69,6 +77,36 @@ public class AdvancedSettingsFragment extends PreferenceFragment implements Pref
                 setPreferencesEnabled(true);
             }
         });
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            prefDbPath.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    if (preference.hasKey() && (preference.getKey().equals(PREF_KEY_DB_PATH))) {
+                        Intent i = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+                        i.addCategory(Intent.CATEGORY_DEFAULT);
+                        startActivityForResult(Intent.createChooser(i, "Choose directory"), PREF_DB_PATH_REQUEST_CODE);
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch(requestCode) {
+            case PREF_DB_PATH_REQUEST_CODE:
+                if (resultCode == Activity.RESULT_OK) {
+                    SharedPreferences.Editor prefs = PreferenceManager.getDefaultSharedPreferences(getContext()).edit();
+                    prefs.putString(PREF_KEY_DB_PATH, data.getDataString());
+                    prefs.apply();
+                }
+                break;
+            default:
+                super.onActivityResult(requestCode, resultCode, data);
+        }
     }
 
     private void setPreferencesEnabled(boolean enabled) {


### PR DESCRIPTION
…ntent

Using ACTION_OPEN_DOCUMENT_TREE we get a directory picker and therefore
always a valid path for the external database.