### PR TITLE
Add LTE cell info.

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/gsmlocation/TelephonyHelper.java
+++ b/app/src/main/java/org/fitchfamily/android/gsmlocation/TelephonyHelper.java
@@ -5,6 +5,8 @@ import android.location.Location;
 import android.os.Bundle;
 import android.telephony.CellIdentityGsm;
 import android.telephony.CellInfoGsm;
+import android.telephony.CellIdentityLte;
+import android.telephony.CellInfoLte;
 import android.telephony.CellLocation;
 import android.telephony.NeighboringCellInfo;
 import android.telephony.TelephonyManager;
@@ -153,6 +155,10 @@ public class TelephonyHelper {
                 CellInfoGsm gsm = (CellInfoGsm) inputCellInfo;
                 CellIdentityGsm id = gsm.getCellIdentity();
                 cellLocation = db.query(id.getMcc(), id.getMnc(), id.getCid(), id.getLac());
+            } else if (inputCellInfo instanceof CellInfoLte) {
+                CellInfoLte lte = (CellInfoLte) inputCellInfo;
+                CellIdentityLte id = lte.getCellIdentity();
+                cellLocation = db.query(id.getMcc(), id.getMnc(), id.getCi(), id.getTac());
             } else if (CellInfoWcdma.isInstance(inputCellInfo)) {
                 try {
                     CellInfoWcdma wcdma = new CellInfoWcdma(inputCellInfo);


### PR DESCRIPTION
The legacyGetCellTowers() function doesn't work on my phone with two sim
cards, because it uses Mnc from first sim and cell ID from second sim and
thus it fails to find the location in database. The patch allows to use
getAllCellInfo() for LTE cells, so that the legacy function doesn't need
to be used at all.

The CellInfoLte is API 17 and the code will fallback to legacy function
if LTE data were not found in database, so it should be safe to use.